### PR TITLE
Update to next@15.3.0-canary.41

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.486.0",
-    "next": "^15.3.0-canary.26",
+    "next": "^15.3.0-canary.41",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "swr": "^2.3.3",


### PR DESCRIPTION
This includes a React bugfix to popstate transitions. (See: https://github.com/facebook/react/pull/32821.) Seems to fix the crashes on back/forward we were seeing.